### PR TITLE
Fix numpy operator error

### DIFF
--- a/ia870/iamat2set.py
+++ b/ia870/iamat2set.py
@@ -8,7 +8,7 @@ def iamat2set(A):
 
 
     if len(A.shape) == 1: A = A[newaxis,:]
-    offsets = nonzero(ravel(A) - ialimits(A)[0])
+    offsets = nonzero(ravel(A) ^ ialimits(A)[0])
     if type(offsets) == type(()):
         offsets = offsets[0]        # for compatibility with numarray
     if len(offsets) == 0: return ([],[])


### PR DESCRIPTION
In recent versions of numpy, it is throwing an error when uses the "-" operator in binary logical operations, forcing the use of "^" operator. This is making several functions not working in recent versios of numpy. This simple fix solve the problem.